### PR TITLE
grant issues permission for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   release-please:


### PR DESCRIPTION
GitHub Actions failed to create labels due to missing "issues: write".
Added explicit permission to allow release-please to work correctly.